### PR TITLE
Invoke FilesViewCallback setCurrentSelection when selection gets cleared

### DIFF
--- a/src/main/java/com/chainstaysoftware/filechooser/IconsFilesView.java
+++ b/src/main/java/com/chainstaysoftware/filechooser/IconsFilesView.java
@@ -308,6 +308,12 @@ class IconsFilesView extends AbstractFilesView {
       @Override
       public void handle(MouseEvent event) {
          if (!(event.getTarget() instanceof IconGridCell)) {
+            selectedCellIndex.setValue(NOT_SELECTED);
+
+            Platform.runLater(() -> {
+               callback.setCurrentSelection(null);
+               IconsFilesView.this.getNode().getParent().requestLayout();
+            });
             return;
          }
 
@@ -375,11 +381,10 @@ class IconsFilesView extends AbstractFilesView {
             event.consume();
          }
 
-         if (selectedCellIndex.get() == NOT_SELECTED) {
-            return;
+         File file = null;
+         if (selectedCellIndex.get() != NOT_SELECTED) {
+            file = gridView.getItems().get(selectedCellIndex.get()).getFile();
          }
-
-         final File file = gridView.getItems().get(selectedCellIndex.get()).getFile();
          callback.setCurrentSelection(file);
       }
    }

--- a/src/main/java/com/chainstaysoftware/filechooser/ListFilesView.java
+++ b/src/main/java/com/chainstaysoftware/filechooser/ListFilesView.java
@@ -425,11 +425,8 @@ class ListFilesView extends AbstractFilesView {
       public void changed(final ObservableValue<? extends TreeItem<File>> observable,
                           final TreeItem<File> oldValue,
                           final TreeItem<File> newValue) {
-         if (newValue == null) {
-            return;
-         }
-
-         callback.setCurrentSelection(newValue.getValue());
+         File newFile = newValue == null ? null : newValue.getValue();
+         callback.setCurrentSelection(newFile);
       }
    }
 

--- a/src/main/java/com/chainstaysoftware/filechooser/ListFilesWithPreviewView.java
+++ b/src/main/java/com/chainstaysoftware/filechooser/ListFilesWithPreviewView.java
@@ -258,17 +258,16 @@ class ListFilesWithPreviewView extends AbstractFilesView {
                           DirectoryListItem newValue) {
          previewHbox.getChildren().clear();
 
-         if (newValue == null) {
-            return;
-         }
-
+         File newFile = newValue == null ? null : newValue.getFile();
 
          ListFilesWithPreviewView.this.getNode().getScene().setCursor(Cursor.WAIT);
          Platform.runLater(() -> {
-            callback.setCurrentSelection(newValue.getFile());
+            callback.setCurrentSelection(newFile);
             ListFilesWithPreviewView.this.getNode().getScene().setCursor(null);
 
-            preview(newValue.getFile());
+            if (newFile != null) {
+               preview(newFile);
+            }
          });
        }
 


### PR DESCRIPTION
In both the list view and the grid view, it is possible to deselect files using control-click. These changes were ignored. However, if that is what the user wants to do, I think we should let him.

This change invokes the callback with null when the file gets unselected.