### PR TITLE
Use a Service for watching current directory

### DIFF
--- a/src/main/java/com/chainstaysoftware/filechooser/DirectoryWatcherTask.java
+++ b/src/main/java/com/chainstaysoftware/filechooser/DirectoryWatcherTask.java
@@ -2,67 +2,63 @@ package com.chainstaysoftware.filechooser;
 
 import javafx.application.Platform;
 import javafx.concurrent.Task;
-import javafx.stage.Stage;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Task to watch for file system changes in the currentDirectory.
+ * Task to watch for file system changes.
  */
-class DirectoryWatcherTask extends Task {
+class DirectoryWatcherTask extends Task<Void> {
    private static Logger logger = Logger.getLogger("com.chainstaysoftware.filechooser.DirectoryWatcherTask");
 
-   private final Stage owner;
-   private final WatchService watcher;
+   private final File directory;
    private final FilesViewCallback callback;
 
-   public DirectoryWatcherTask(final Stage owner,
-                               final WatchService watcher,
+   public DirectoryWatcherTask(final File directory,
                                final FilesViewCallback callback) {
-      this.owner = owner;
-      this.watcher = watcher;
+      this.directory = directory;
       this.callback = callback;
    }
 
    @Override
-   protected Object call() throws Exception {
-      while (true) {
-         WatchKey key;
-         try {
-            final long timeout = 5;
-            key = watcher.poll(timeout, TimeUnit.SECONDS);
-         } catch (InterruptedException ex) {
-            return null;
-         }
+   protected Void call() {
+      try (FileSystem fileSystem = directory.toPath().getFileSystem();
+           WatchService watcher = fileSystem.newWatchService()) {
+         directory.toPath().register(watcher,
+                 StandardWatchEventKinds.ENTRY_CREATE,
+                 StandardWatchEventKinds.ENTRY_DELETE,
+                 StandardWatchEventKinds.ENTRY_MODIFY);
+         while (!isCancelled()) {
+            WatchKey key = watcher.take();
 
-         if (shouldShutdownTask()) {
-            break;
-         }
+            if (key.pollEvents().isEmpty()) {
+               continue;
+            }
 
-         if (key == null || key.pollEvents().isEmpty()) {
-            continue;
-         }
+            logger.log(Level.FINE, "Directory contents changed. Updating view.");
+            Platform.runLater(callback::updateFiles);
 
-         logger.log(Level.FINE, "Directory contents changed. Updating view.");
-         Platform.runLater(callback::updateFiles);
-
-         boolean valid = key.reset();
-         if (!valid) {
-            break;
+            boolean valid = key.reset();
+            if (!valid) {
+               break;
+            }
          }
+      } catch (InterruptedException e) {
+         if (!isCancelled()) {
+            logger.log(Level.FINE, "interrupted while waiting for key: " + e.getMessage());
+         }
+      } catch (IOException e) {
+         logger.log(Level.FINE, "watching " + directory + " failed: " + e.getMessage());
       }
 
       logger.log(Level.FINE, "exiting watcher task");
       return null;
    }
-
-   private Boolean shouldShutdownTask() {
-      return (Boolean)owner.getUserData();
-   }
 }
-
-

--- a/src/main/java/com/chainstaysoftware/filechooser/FileChooserFxImpl.java
+++ b/src/main/java/com/chainstaysoftware/filechooser/FileChooserFxImpl.java
@@ -73,6 +73,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.ResourceBundle;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -93,7 +95,7 @@ public final class FileChooserFxImpl implements FileChooserFx {
    private final ObservableList<File> favoriteDirs = FXCollections.observableArrayList();
    private final Deque<File> directoryStack = new LinkedList<>();
    private final ObjectProperty<File> currentSelection = new SimpleObjectProperty<>();
-   private final UpdateWatchKeyService updateWatchKeyService = new UpdateWatchKeyService();
+   private final DirectoryWatchingService dirWatchingService = new DirectoryWatchingService(new FilesViewCallbackImpl());
    private final BooleanProperty hideFiles = new SimpleBooleanProperty(this, "shouldHideFiles", false);
 
    private double placesDivider = PLACES_DIVIDER_POSITION;
@@ -131,8 +133,6 @@ public final class FileChooserFxImpl implements FileChooserFx {
    private Button removeFavoriteButton;
    private Button doneButton;
    private Icons icons = new IconsImpl();
-   private WatchService watcher;
-   private WatchKey watchKey;
 
    /**
     * Property representing the height of the FileChooser.
@@ -527,11 +527,9 @@ public final class FileChooserFxImpl implements FileChooserFx {
       stage.setScene(scene);
       stage.initOwner(ownerWindow);
       stage.initModality(Modality.APPLICATION_MODAL);
-      stage.setUserData(Boolean.FALSE);
-      stage.setOnCloseRequest(event -> {
-         stage.setUserData(Boolean.TRUE);
-         fileChooserCallback.fileChosen(Optional.empty());
-      });
+      stage.setOnShown(event -> updateWatchDirectory());
+      stage.setOnHidden(event -> dirWatchingService.cancel());
+      stage.setOnCloseRequest(event -> fileChooserCallback.fileChosen(Optional.empty()));
       stage.show();
 
       placesView.updatePlaces();
@@ -1383,41 +1381,51 @@ public final class FileChooserFxImpl implements FileChooserFx {
     * Setup WatchService to watch for file system changes.
     */
    private void updateWatchDirectory() {
-      try {
-         if (watcher == null) {
-            watcher = FileSystems.getDefault().newWatchService();
+      dirWatchingService.setDirectory(currentDirectory);
 
-            final Thread watcherThread = new Thread(new DirectoryWatcherTask(stage,
-                  watcher, new FilesViewCallbackImpl()));
-            watcherThread.setDaemon(true);
-            watcherThread.start();
-         }
-
-         updateWatchKeyService.restart();
-
-      } catch (IOException e) {
-         logger.log(Level.WARNING, "Error setting up WatchService", e);
+      if (currentDirectory == null) {
+         dirWatchingService.cancel();
+      }
+      else {
+         dirWatchingService.restart();
       }
    }
 
-   private class UpdateWatchKeyService extends Service<Void> {
+   private static final class DirectoryWatchingService extends Service<Void> {
+      private final ObjectProperty<File> directory;
+      private final FilesViewCallback callback;
+
+      private DirectoryWatchingService(FilesViewCallback callback) {
+         this.callback = callback;
+
+         directory = new SimpleObjectProperty<>();
+
+         setExecutor(Executors.newSingleThreadExecutor(new DaemonThreadFactory()));
+      }
+
+      public File getDirectory() {
+         return directory.get();
+      }
+
+      public void setDirectory(File directory) {
+         this.directory.set(directory);
+      }
+
       @Override
       protected Task<Void> createTask() {
-         return new Task<Void>() {
-            @Override
-            protected Void call() throws Exception {
-               synchronized (this) {
-                  if (watchKey != null) {
-                     watchKey.cancel();
-                  }
+         File currentDirectory = getDirectory();
+         logger.log(Level.FINE, "Creating watch task for " + currentDirectory);
 
-                  watchKey = currentDirectory.toPath().register(watcher, StandardWatchEventKinds.ENTRY_CREATE,
-                     StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
-               }
+         return new DirectoryWatcherTask(currentDirectory, callback);
+      }
+   }
 
-               return null;
-            }
-         };
+   private static final class DaemonThreadFactory implements ThreadFactory {
+      @Override
+      public Thread newThread(Runnable runnable) {
+         Thread thread = new Thread(runnable);
+         thread.setDaemon(true);
+         return thread;
       }
    }
 


### PR DESCRIPTION
The directory watching in FileChooserFxImpl is quite complicated and relies on a magic shared Boolean to control the background task.

This pull request changes the uncontrollable background thread into a JavaFX services that is started/canceled as needed. It also considerably simplifies things by not trying to reuse the WatchService/WatchKey and instead making new ones and cleaning them up in the background task.